### PR TITLE
Add display impl on errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ impl Display for UrlParseError {
         match self {
             UrlParseError::NoPath => write!(f, "URL path is missing."),
             UrlParseError::NotHttps => write!(f, "The URL protocol should be https."),
-            UrlParseError::Parser(e) => write!(f, "Error while parsing: {}", e),
+            UrlParseError::Parser(e) => write!(f, "Error while parsing the URL: {}", e),
         }
     }
 }


### PR DESCRIPTION
Adding a display implementation on errors allows consumers of the library to treat errors like generic standard error and the ability to use the question mark operator in functions returning multiplet types of errors (as long as they use an error library such as anyhow) without having to resort to a bunch of `map_err()`.

A few formatting fixes from rustfmt.

Finally, one change replacing a `map` by a `for (k, v) in self.params.iter()` loop, since the compiler wasn't allowing the creation of a collection without consuming it.