### PR TITLE
Distinguish between PUT/POST requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "firebase-rs"
-version = "2.0.5"
+version = "3.0.0"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "firebase-rs"
 edition = "2021"
-version = "2.0.5"
+version = "3.0.0"
 description = "Rust based Firebase library"
 readme = "README.md"
 repository = "https://github.com/emreyalvac/firebase-rs"
-documentation = "https://docs.rs/firebase-rs/2.0.4/firebase_rs/"
+documentation = "https://docs.rs/firebase-rs/3.0.0/firebase_rs/"
 license = "MIT"
 authors = ["Emre YALVAÇ <emre.yalvac@outlook.com>"]
 exclude = ["examples/*", "tests/*"]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,6 +13,7 @@ pub const EXPORT: &str = "export";
 pub enum Method {
     GET,
     POST,
+    PUT,
     DELETE,
     PATCH,
 }


### PR DESCRIPTION
# Description

Currently, when using this library with the Realtime Database, the `set()` function uses a `POST` request and thus inserts the provided data under a new key. Is this the intended behavior?
I would have expected to set the data at the provided path (without new sub-key), ie using [`PUT`](https://firebase.google.com/docs/reference/rest/database#section-put).

# Example
```rust
#[derive(Debug, Default, Serialize, Deserialize)]
#[serde(default)]
struct SensorData {
    #[serde(rename = "t", skip_serializing_if = "Option::is_none")]
    temperature: Option<f32>,
    #[serde(rename = "h", skip_serializing_if = "Option::is_none")]
    humidity: Option<f32>,
    #[serde(rename = "d", skip_serializing_if = "Option::is_none")]
    dewpoint: Option<f32>,
}

let firebase = Firebase::new("https://xxx.firebasedatabase.app").unwrap();
let unix_time = start.duration_since(UNIX_EPOCH).unwrap().as_secs();
let data = SensorData {
    temperature: Some(42.0),
    ..Default::default()
};

firebase
    .at("weather")
    .at(&format!("{}", &unix_time))
    .set(&data)
    .await
    .expect("error writing to firebase");
```

Results in the following db entries:

![image](https://user-images.githubusercontent.com/2405792/207918042-c72b6d51-93e5-4acb-b0d9-523160b0e255.png)



# Proposed changes

* Rename old `set()` to `insert()`
* Add new `set()` that uses `PUT`
* Fixes code formatting