### PR TITLE
Add Send Trait to SSE Stream Return Type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "firebase-rs"
-version = "2.0.7"
+version = "2.0.8"
 dependencies = [
  "eventsource-client",
  "futures-util",

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -37,7 +37,8 @@ impl ServerEvents {
     pub fn stream(
         self,
         keep_alive_friendly: bool,
-    ) -> std::pin::Pin<Box<dyn futures_util::Stream<Item = Result<(String, Option<String>)>>>> {
+    ) -> std::pin::Pin<Box<dyn futures_util::Stream<Item = Result<(String, Option<String>)>> + Send>>
+    {
         return Box::pin(
             self.client
                 .build()


### PR DESCRIPTION
Hey there!

I've made a small tweak to the SSE stream return type by adding the `Send` trait. Without this trait, the `stream` method can't be used in a Tokio thread. Fr example, this code

```rust
let updates_handle = tokio::spawn(async move {
        let stream = Firebase::new(&some_url)
            .unwrap()
            .at("updates")
            .with_realtime_events()
            .unwrap()
            .stream(true);
        stream
            .for_each(|event| {
                match event {
                    Ok((event_type, maybe_data)) => println!("{:?} {:?}", event_type, maybe_data),
                    Err(err) => println!("{:?}", err),
                }
                futures_util::future::ready(())
            })
            .await;
    });
    updates_handle
        .await
        .expect("SSE background update has panicked!");
```
returns the following error:

```
the trait `std::marker::Send` is not implemented for `dyn Stream<Item = Result<(std::string::String, Option<std::string::String>), eventsource_client::error::Error>>`
```

The original eventsource `Stream` return type includes the `Send` trait, and according to the compiler, everything else is `Send` as well. After adding` Send`, everything compiles and works just fine.

Looking forward to your thoughts!