### PR TITLE
refactor: use function traits instead of function pointers for listen method

### DIFF
--- a/src/sse.rs
+++ b/src/sse.rs
@@ -19,8 +19,8 @@ impl ServerEvents {
 
     pub async fn listen(
         self,
-        stream_event: fn(String, Option<String>),
-        stream_err: fn(Error),
+        stream_event: impl Fn(String, Option<String>),
+        stream_err: impl Fn(Error),
         keep_alive_friendly: bool,
     ) {
         self.stream(keep_alive_friendly)


### PR DESCRIPTION
Pointer function can easily be coerced into closures if such capture outside value, rendering handling of the server-sent-events difficult. For instance:

```rust
let (tx, rx) = mpsc::channel();

firebase.listen(move |_, payload| {
    tx.send(payload.unwrap());
});
```

Will throws compile time error: `closures can only be coerced to `fn` types if they do not capture any variables`