### PR TITLE
fix: #25. Expose errors as public

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,13 +51,13 @@ impl Display for RequestError {
 
 #[derive(Debug)]
 pub enum ServerEventError {
-    _ConnectionError,
+    ConnectionError,
 }
 
 impl Display for ServerEventError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ServerEventError::_ConnectionError => write!(f, "Connection error for server events"),
+            ServerEventError::ConnectionError => write!(f, "Connection error for server events"),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -54,6 +54,8 @@ pub enum ServerEventError {
     ConnectionError,
 }
 
+impl Error for ServerEventError {}
+
 impl Display for ServerEventError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,7 @@
-use std::{error::Error, fmt::{Display, Formatter}};
+use std::{
+    error::Error,
+    fmt::{Display, Formatter},
+};
 
 pub type UrlParseResult<T> = Result<T, UrlParseError>;
 
@@ -48,7 +51,7 @@ impl Display for RequestError {
 
 #[derive(Debug)]
 pub enum ServerEventError {
-    ConnectionError,
+    _ConnectionError,
 }
 
 impl Display for ServerEventError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -57,7 +57,7 @@ pub enum ServerEventError {
 impl Display for ServerEventError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ServerEventError::ConnectionError => write!(f, "Connection error for server events"),
+            ServerEventError::_ConnectionError => write!(f, "Connection error for server events"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use std::fmt::Debug;
 use url::Url;
 use utils::check_uri;
-use crate::errors::ServerEventError;
+
 use crate::sse::ServerEvents;
 
 mod constants;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use constants::{Method, Response, AUTH};
-use errors::{RequestError, RequestResult, UrlParseError, UrlParseResult};
+use errors::{RequestResult, UrlParseResult};
 use params::Params;
 use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
@@ -10,6 +10,8 @@ use url::Url;
 use utils::check_uri;
 
 use crate::sse::ServerEvents;
+
+pub use errors::{RequestError, ServerEventError, UrlParseError};
 
 mod constants;
 mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ use crate::sse::ServerEvents;
 mod constants;
 mod errors;
 mod params;
-mod utils;
 mod sse;
+mod utils;
 
 #[derive(Debug)]
 pub struct Firebase {
@@ -29,8 +29,8 @@ impl Firebase {
     /// let firebase = Firebase::new("https://myfirebase.firebaseio.com").unwrap();
     /// ```
     pub fn new(uri: &str) -> UrlParseResult<Self>
-        where
-            Self: Sized,
+    where
+        Self: Sized,
     {
         match check_uri(&uri) {
             Ok(uri) => Ok(Self { uri }),
@@ -47,8 +47,8 @@ impl Firebase {
     /// let firebase = Firebase::auth("https://myfirebase.firebaseio.com", AUTH_KEY).unwrap();
     /// ```
     pub fn auth(uri: &str, auth_key: &str) -> UrlParseResult<Self>
-        where
-            Self: Sized,
+    where
+        Self: Sized,
     {
         match check_uri(&uri) {
             Ok(mut uri) => {
@@ -131,9 +131,7 @@ impl Firebase {
 
         let mut uri = self.uri.clone();
         uri.set_path(&format!("{}.json", new_path));
-        Self {
-            uri,
-        }
+        Self { uri }
     }
 
     /// ```rust
@@ -212,8 +210,8 @@ impl Firebase {
     }
 
     async fn request_generic<T>(&self, method: Method) -> RequestResult<T>
-        where
-            T: Serialize + DeserializeOwned + Debug,
+    where
+        T: Serialize + DeserializeOwned + Debug,
     {
         let request = self.request(method, None).await;
 
@@ -243,8 +241,8 @@ impl Firebase {
     /// # }
     /// ```
     pub async fn set<T>(&self, data: &T) -> RequestResult<Response>
-        where
-            T: Serialize + DeserializeOwned + Debug,
+    where
+        T: Serialize + DeserializeOwned + Debug,
     {
         let data = serde_json::to_value(&data).unwrap();
         self.request(Method::POST, Some(data)).await
@@ -290,8 +288,8 @@ impl Firebase {
     /// # }
     /// ```
     pub async fn get<T>(&self) -> RequestResult<T>
-        where
-            T: Serialize + DeserializeOwned + Debug,
+    where
+        T: Serialize + DeserializeOwned + Debug,
     {
         self.request_generic::<T>(Method::GET).await
     }
@@ -324,8 +322,8 @@ impl Firebase {
     /// # }
     /// ```
     pub async fn update<T>(&self, data: &T) -> RequestResult<Response>
-        where
-            T: DeserializeOwned + Serialize + Debug,
+    where
+        T: DeserializeOwned + Serialize + Debug,
     {
         let value = serde_json::to_value(&data).unwrap();
         self.request(Method::PATCH, Some(value)).await

--- a/src/params.rs
+++ b/src/params.rs
@@ -2,9 +2,9 @@ use crate::constants::{
     END_AT, EQUAL_TO, EXPORT, FORMAT, LIMIT_TO_FIRST, LIMIT_TO_LAST, ORDER_BY, SHALLOW, START_AT,
 };
 use crate::Firebase;
+use itertools::Itertools;
 use std::collections::HashMap;
 use url::Url;
-use itertools::Itertools;
 
 #[derive(Debug)]
 pub struct Params {
@@ -27,8 +27,8 @@ impl Params {
     }
 
     pub fn add_param<T>(&mut self, key: &str, value: T) -> &mut Self
-        where
-            T: ToString,
+    where
+        T: ToString,
     {
         self.params.insert(key.to_string(), value.to_string());
         self.set_params();
@@ -73,21 +73,26 @@ impl Params {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
+    use crate::params::Params;
     use std::collections::HashMap;
     use url::Url;
-    use crate::params::Params;
 
     #[test]
     fn check_params() {
         let mut params: HashMap<String, String> = HashMap::new();
         params.insert("param_1".to_owned(), "value_1".to_owned());
         params.insert("param_2".to_owned(), "value_2".to_owned());
-        let mut param = Params { uri: Url::parse("https://github.com/emreyalvac").unwrap(), params };
+        let mut param = Params {
+            uri: Url::parse("https://github.com/emreyalvac").unwrap(),
+            params,
+        };
         param.set_params();
 
-        assert_eq!(param.uri.as_str(), "https://github.com/emreyalvac?param_1=value_1&param_2=value_2")
+        assert_eq!(
+            param.uri.as_str(),
+            "https://github.com/emreyalvac?param_1=value_1&param_2=value_2"
+        )
     }
 }

--- a/src/sse.rs
+++ b/src/sse.rs
@@ -7,7 +7,7 @@ pub struct ServerEvents {
 
 impl ServerEvents {
     pub fn new(url: &str) -> Option<Self> {
-        let mut client = ClientBuilder::for_url(url);
+        let client = ClientBuilder::for_url(url);
 
         match client {
             Ok(stream_connection) => Some(ServerEvents {


### PR DESCRIPTION
This PR fixes #25 by simply exposing `errors::{RequestError, ServerEventError, UrlParseError}`  as `pub`.
It also adds a missing `impl Error` for `ServerEventError`. I am not sure why this error enum exists, it doesn't seem to be used anywhere so it might be better to just remove it.
It is built on top of #31 so it should be merged after that one.

