### PR TITLE
fix: remove serde's DeserializeOwned trait bound for the update method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@ impl Firebase {
     /// ```
     pub async fn update<T>(&self, data: &T) -> RequestResult<Response>
     where
-        T: DeserializeOwned + Serialize + Debug,
+        T: Serialize + Debug,
     {
         let value = serde_json::to_value(&data).unwrap();
         self.request(Method::PATCH, Some(value)).await


### PR DESCRIPTION
The `update` method call just needs to serialize data into `serde::Value`, therefore the trait bound `DeserializeOwned` is not necessary.

Tested and working fine.