### PR TITLE
fix: Don't return Error::StreamClosed when SSE connects successfully

### DIFF
--- a/src/sse.rs
+++ b/src/sse.rs
@@ -56,9 +56,8 @@ impl ServerEvents {
 
                             return Some(Ok((ev.event_type, Some(ev.data))));
                         }
-                        Ok(SSE::Comment(_)) => return None,
+                        Ok(SSE::Comment(_)) | Ok(SSE::Connected(_)) => return None,
                         Err(x) => Some(Err(x)),
-                        _ => Some(Err(Error::StreamClosed)),
                     }
                 }),
         )


### PR DESCRIPTION
We've noticed when using SSE that we always see `Error::StreamClosed` immediately after connecting. After a bit of digging I found some code that ends up converting the `SSE::Connected` event to `StreamClosed`. This is obviously not ideal. Here's a small patch to ignore `SSE::Connected` instead.