### PR TITLE
fix: Replace `.unwrap()` calls with error propagation

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,7 @@ use std::{
 pub type UrlParseResult<T> = Result<T, UrlParseError>;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum UrlParseError {
     NoPath,
     NotHttps,
@@ -27,11 +28,13 @@ impl Display for UrlParseError {
 pub type RequestResult<T> = Result<T, RequestError>;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum RequestError {
     NotJSON,
     NoUTF8,
     NetworkError,
-    SerializeError,
+    SerializeError(serde_json::Error),
+    DeserializeError(serde_json::Error),
     NotFoundOrNullBody,
     Unauthorized,
 }
@@ -44,7 +47,8 @@ impl Display for RequestError {
             RequestError::NotJSON => write!(f, "Invalid JSON"),
             RequestError::NoUTF8 => write!(f, "Utf8 error"),
             RequestError::NetworkError => write!(f, "Network error"),
-            RequestError::SerializeError => write!(f, "Serialize error"),
+            RequestError::SerializeError(e) => write!(f, "Failed to serialize request: {}", e),
+            RequestError::DeserializeError(e) => write!(f, "Failed to deserialize response: {}", e),
             RequestError::NotFoundOrNullBody => write!(f, "Body is null or record is not found"),
             RequestError::Unauthorized => write!(f, "Unauthorized"),
         }
@@ -52,6 +56,7 @@ impl Display for RequestError {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ServerEventError {
     ConnectionError,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,15 +199,9 @@ impl Firebase {
 
         match request {
             Ok(response) => {
-                // Step 1: Parse raw JSON string into a generic Value.
-                // If this fails, the response wasn't valid JSON at all.
                 let value: serde_json::Value = serde_json::from_str(response.data.as_str())
                     .map_err(|_| RequestError::NotJSON)?;
 
-                // Step 2: Convert the Value into the caller's target type.
-                // If this fails, the JSON was valid but its shape doesn't
-                // match T — serde's error message includes the problematic
-                // field / expected type so callers get actionable context.
                 let data: T = serde_json::from_value(value)
                     .map_err(RequestError::DeserializeError)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ impl Firebase {
             Method::GET => client.get(self.uri.to_string()).send().await,
             Method::PUT | Method::PATCH | Method::POST => {
                 if data.is_none() {
-                    return Err(RequestError::SerializeError);
+                    return Err(RequestError::NotFoundOrNullBody);
                 }
                 let builder = if method == Method::PUT {
                     client.put(self.uri.to_string())
@@ -199,7 +199,17 @@ impl Firebase {
 
         match request {
             Ok(response) => {
-                let data: T = serde_json::from_str(response.data.as_str()).unwrap();
+                // Step 1: Parse raw JSON string into a generic Value.
+                // If this fails, the response wasn't valid JSON at all.
+                let value: serde_json::Value = serde_json::from_str(response.data.as_str())
+                    .map_err(|_| RequestError::NotJSON)?;
+
+                // Step 2: Convert the Value into the caller's target type.
+                // If this fails, the JSON was valid but its shape doesn't
+                // match T — serde's error message includes the problematic
+                // field / expected type so callers get actionable context.
+                let data: T = serde_json::from_value(value)
+                    .map_err(RequestError::DeserializeError)?;
 
                 Ok(data)
             }
@@ -226,7 +236,7 @@ impl Firebase {
     where
         T: Serialize + Debug,
     {
-        let data = serde_json::to_value(&data).unwrap();
+        let data = serde_json::to_value(&data).map_err(RequestError::SerializeError)?;
         self.request(Method::POST, Some(data)).await
     }
 
@@ -250,7 +260,7 @@ impl Firebase {
         T: Serialize + Debug,
     {
         self.uri = self.build_uri(key);
-        let data = serde_json::to_value(&data).unwrap();
+        let data = serde_json::to_value(&data).map_err(RequestError::SerializeError)?;
 
         self.request(Method::PUT, Some(data)).await
     }
@@ -332,7 +342,7 @@ impl Firebase {
     where
         T: Serialize + Debug,
     {
-        let value = serde_json::to_value(&data).unwrap();
+        let value = serde_json::to_value(&data).map_err(RequestError::SerializeError)?;
         self.request(Method::PATCH, Some(value)).await
     }
 }


### PR DESCRIPTION
Currently, there are a few error paths that call `.unwrap()` in contexts where it isn't safe to do so and cause panics. This produces difficult to debug panics like:
```text
thread 'tokio-rt-worker' (7) panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/firebase-rs-2.2.3/src/lib.rs:202:76:
called `Result::unwrap()` on an `Err` value: Error("invalid type: null, expected a sequence", line: 1, column: 4)
```

For example, the deserialization in `request_generic` isn't safe to unwrap because Firebase likes to pass empty vectors back as `null`.

This is a breaking change requiring a major semver bump, but the solution I propose is adding an error variant for deserialization errors. I did the following:
- Deserialization in `request_generic` now uses two-step parsing so callers get actionable serde context on type mismatches instead of a panic
- `SerializeError` and `DeserializeError` now thread `serde_json::Error`, which users can utilize to get additional context on what happened
- Added `#[non_exhaustive]` to all public error enums, which helps make it clear to implementers that error types for the crate are subject to change, requiring a catchall pattern. Major benefit is that any later-introduced error variants aren't breaking changes

This PR is human-written. Changes were made with Claude Opus 4.6 (1M).